### PR TITLE
Travis build error

### DIFF
--- a/.#build.sh
+++ b/.#build.sh
@@ -4,11 +4,11 @@
 # Rscript -e "install.packages('roxygen2', repos = 'http://cran.us.r-project.org')"
 Rscript -e "devtools::document('R')"
 
-Rscript -e "devtools::Rcpp::compileAttributes()"
+Rscript -e "install.packages('Rcpp', repos = 'http://cran.us.r-project.org')"
+Rscript -e "Rcpp::compileAttributes()"
 R CMD build --resave-data .
 
 # Rscript -e "install.packages('dummies', repos = 'http://cran.us.r-project.org')"
-# Rscript -e "install.packages('Rcpp', repos = 'http://cran.us.r-project.org')"
 # Rscript -e "install.packages('RcppArmadillo', repos = 'http://cran.us.r-project.org')"
 # Rscript -e "install.packages('RcppZiggurat', repos = 'http://cran.us.r-project.org')"
 # Rscript -e "install.packages('testthat', repos = 'http://cran.us.r-project.org')"

--- a/.#build_win.ps1
+++ b/.#build_win.ps1
@@ -2,11 +2,11 @@
 # Rscript.exe -e "install.packages('roxygen2', repos = 'http://cran.us.r-project.org')"
 Rscript.exe -e "devtools::document('R')"
 
-Rscript.exe -e "devtools::Rcpp::compileAttributes()"
+Rscript.exe -e "install.packages('Rcpp', repos = 'http://cran.us.r-project.org')"
+Rscript.exe -e "Rcpp::compileAttributes()"
 R.exe CMD build --resave-data .
 
 # Rscript.exe -e "install.packages('dummies', repos = 'http://cran.us.r-project.org')"
-# Rscript.exe -e "install.packages('Rcpp', repos = 'http://cran.us.r-project.org')"
 # Rscript.exe -e "install.packages('RcppArmadillo', repos = 'http://cran.us.r-project.org')"
 # Rscript.exe -e "install.packages('RcppZiggurat', repos = 'http://cran.us.r-project.org')"
 # Rscript.exe -e "install.packages('testthat', repos = 'http://cran.us.r-project.org')"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ script:
   #- cd tests
   - printf "starting testthat run\n"
   #- Rscript testthat.R
-  - Rscript -e 'devtools::Rcpp::compileAttributes();devtools::install(local=FALSE);devtools::test()'
+  - Rscript -e "install.packages('Rcpp', repos = 'http://cran.us.r-project.org');Rcpp::compileAttributes()"
+  - Rscript -e "devtools::install(local=FALSE);devtools::test()"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ script:
   #- cd tests
   - printf "starting testthat run\n"
   #- Rscript testthat.R
-  - Rscript -e 'devtools::install(local=FALSE);devtools::test()'
+  - Rscript -e 'devtools::Rcpp::compileAttributes();devtools::install(local=FALSE);devtools::test()'


### PR DESCRIPTION
This should fix the error we have in Travis as it tries to build `rerf`.  I am not sure how travis has been passing while still failing to build rerf -- perhaps it's using a cached version?

This is the error we were getting in the travis log:
```
make: *** No rule to make target `RcppExports.o', needed by `rerf.so'.  Stop.
```

And the command to fix this error is: `Rcpp::compileAttributes()`

I also updated our build scripts to properly run this command.