### PR TITLE
Add OOBpredict warning for when NA's are generated [closes #78]

### DIFF
--- a/R/OOBPredict.R
+++ b/R/OOBPredict.R
@@ -26,7 +26,7 @@ OOBPredict <- function(X, forest, num.cores = 0L, Xtrain = NULL, output.scores =
   predictions <- Predict(X = X, forest = forest, OOB = TRUE, num.cores = num.cores, 
     Xtrain = Xtrain, output.scores = output.scores)
 
-  if (any(is.na(preditions))) {
+  if (any(is.na(predictions))) {
     num <- sum(is.na(predictions))
     mes1 <- sprintf("NA's generated in the OOB predictions because %d/%d observations were never out-of-bag.",
       num, length(predictions))

--- a/R/OOBPredict.R
+++ b/R/OOBPredict.R
@@ -26,12 +26,21 @@ OOBPredict <- function(X, forest, num.cores = 0L, Xtrain = NULL, output.scores =
   predictions <- Predict(X = X, forest = forest, OOB = TRUE, num.cores = num.cores, 
     Xtrain = Xtrain, output.scores = output.scores)
 
-  if (any(is.na(predictions))) {
+  mes1 <- c("NA's generated in the OOB predictions because %d/%d observations were never out-of-bag.")
+  mes2 <- "\nA fix for this is to re-train the forest using more trees."
+
+  if (!output.scores && any(is.na(predictions))) {
     num <- sum(is.na(predictions))
-    mes1 <- sprintf("NA's generated in the OOB predictions because %d/%d observations were never out-of-bag.",
-      num, length(predictions))
-    mes2 <- "\nA fix for this is to re-train the forest using more trees."
-    warning(paste(mes1, mes2), call. = TRUE)
+    warning(paste(sprintf(mes1, num, nrow(X)), mes2), call. = TRUE)
   }
+
+  if (output.scores && any(is.na(predictions))) {
+    num <- sum(is.na(predictions[, 1]))
+    warning(paste(sprintf(mes1, num, nrow(X)), mes2), call. = TRUE)
+  }
+
   return(predictions)
 }
+
+
+

--- a/R/OOBPredict.R
+++ b/R/OOBPredict.R
@@ -25,5 +25,13 @@
 OOBPredict <- function(X, forest, num.cores = 0L, Xtrain = NULL, output.scores = FALSE) {
   predictions <- Predict(X = X, forest = forest, OOB = TRUE, num.cores = num.cores, 
     Xtrain = Xtrain, output.scores = output.scores)
+
+  if (any(is.na(preditions))) {
+    num <- sum(is.na(predictions))
+    mes1 <- sprintf("NA's generated in the OOB predictions because %d/%d observations were never out-of-bag.",
+      num, length(predictions))
+    mes2 <- "\nA fix for this is to re-train the forest using more trees."
+    warning(paste(mes1, mes2), call. = TRUE)
+  }
   return(predictions)
 }


### PR DESCRIPTION
Below is a test function and a sample run. 

```r
testit <- function(){
predictions <- rep(NA, 3)
 if (any(is.na(predictions))) {
    num <- sum(is.na(predictions))
    mes1 <- sprintf("NA's generated in the OOB predictions because %d/%d observations were never out-of-bag.",
      num, length(predictions))
    mes2 <- "\nA fix for this is to re-train the forest using more trees."
    warning(paste(mes1, mes2), call. = TRUE)
  }
}
```

```
> testit()
Warning message:
In testit() :
  NA's generated in the OOB predictions because 3/3 observations were never out-of-bag. 
A fix for this is to re-train the forest using more trees.
```
